### PR TITLE
fix: update yarn add command to include package prefix, failing for m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To Install this plugin you'll need to do the following:
     ```
 	npm install https://github.com/liatrio/backstage-liatrio-dora-plugin/releases/download/v0.3.14/liatrio-backstage-plugin-liatrio-dora-v0.3.14.tgz
 
-	yarn add https://github.com/liatrio/backstage-liatrio-dora-plugin/releases/download/v0.3.14/liatrio-backstage-plugin-liatrio-dora-v0.3.14.tgz
+	yarn add backstage-liatrio-dora-plugin@https://github.com/liatrio/backstage-liatrio-dora-plugin/releases/download/v0.3.14/liatrio-backstage-plugin-liatrio-dora-v0.3.14.tgz
 	```
 
 2. Update the `/packages/app/src/App.tsx` file:


### PR DESCRIPTION
Update yarn add command get the error `Usage Error: It seems you are trying to add a package using a https:... url; we now require package names to be explicitly specified.`

![Screenshot 2024-08-19 at 2 57 24 PM](https://github.com/user-attachments/assets/4e9ceef6-14da-4145-8bf8-1200be1617cb)
